### PR TITLE
Phase 0 (导航): GitHub 三层导航 + 角色门控 + EOA/AirAccount 分层

### DIFF
--- a/aastar-frontend/app/phase0/page.tsx
+++ b/aastar-frontend/app/phase0/page.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { formatUnits } from "viem";
 import type { Address } from "viem";
 import { Cos72SessionProvider, useCos72Session } from "@/contexts/Cos72SessionContext";
+import { CommunityNav } from "@/components/nav/CommunityNav";
 import { infraAddresses } from "@/lib/addresses";
 import { listCommunityTokens, readCredibility, type Credibility } from "@/lib/community";
 
@@ -112,8 +113,15 @@ export default function Phase0Page() {
       <main className="mx-auto max-w-2xl space-y-4 p-6">
         <h1 className="text-xl font-bold">Cos72 Phase 0 — 共享层验证</h1>
         <p className="text-sm text-gray-500">
-          验证会话 / canonical 地址 / 社区可信度。写路径（cosSend）待后端 /userop 上线。
+          验证会话 / canonical 地址 / 社区可信度 / 角色导航。写路径（cosSend）待后端 /userop 上线。
         </p>
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-2 font-semibold">0.4 社区导航（L2，按链上角色显隐）</h2>
+          <CommunityNav active="overview" />
+          <p className="mt-2 text-xs text-gray-400">
+            治理 / 发币仅社区 owner 可见；运维·Operator（EOA 轨道）仅持 operator 角色可见。
+          </p>
+        </section>
         <SessionPanel />
         <AddressPanel />
         <CredibilityPanel />

--- a/aastar-frontend/components/nav/CommunityNav.tsx
+++ b/aastar-frontend/components/nav/CommunityNav.tsx
@@ -1,0 +1,107 @@
+/**
+ * L2 community navigation (Phase 0 §0.4) — the GitHub-org-style horizontal tabs
+ * shown once you're inside a community. The tabs are the modules, common to all
+ * communities, gated by the account's on-chain role:
+ *
+ *   L1 用户菜单（跨社区）= 沿用 YAAA 右上用户菜单（不在此）
+ *   L2 社区菜单（本组件）= 概览 / MyTask / MyShop / MyVote / 成员 / 治理·发币(owner)
+ *   L3 模块子导航        = 各模块自己的 sub-nav（进入模块后，本 PR 不含）
+ *
+ * EOA 分层：infra/operator（部署 / DVT-register，EOA 轨道）不是社区 tab —— 单独一个
+ * 「运维」入口（链到现有 app/operator/*），仅在账户持 operator 角色时出现。
+ *
+ * @module components/nav/CommunityNav
+ */
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useCos72Session } from "@/contexts/Cos72SessionContext";
+import { EMPTY_ROLES, readRoles, type RoleFlags } from "@/lib/roles";
+
+type Tab = {
+  key: string;
+  label: string;
+  href: string;
+  /** Only shown when the account is a community owner. */
+  ownerOnly?: boolean;
+  /** Module not built yet — render disabled. */
+  soon?: boolean;
+};
+
+const TABS: Tab[] = [
+  { key: "overview", label: "概览", href: "#" },
+  { key: "mytask", label: "MyTask", href: "#", soon: true },
+  { key: "myshop", label: "MyShop", href: "#", soon: true },
+  { key: "myvote", label: "MyVote", href: "#", soon: true },
+  { key: "members", label: "成员", href: "#" },
+  { key: "governance", label: "治理", href: "#", ownerOnly: true },
+  { key: "issue", label: "发币", href: "#", ownerOnly: true },
+];
+
+/** Load the connected account's roles (empty until logged in / loaded). */
+function useRoles(): { roles: RoleFlags; loading: boolean } {
+  const { address } = useCos72Session();
+  const [roles, setRoles] = useState<RoleFlags>(EMPTY_ROLES);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    if (!address) {
+      setRoles(EMPTY_ROLES);
+      return;
+    }
+    setLoading(true);
+    readRoles(address)
+      .then((r) => !cancelled && setRoles(r))
+      .catch(() => !cancelled && setRoles(EMPTY_ROLES))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+  return { roles, loading };
+}
+
+export function CommunityNav({ active }: { active?: string }) {
+  const { roles, loading } = useRoles();
+  const tabs = TABS.filter((t) => !t.ownerOnly || roles.community);
+
+  return (
+    <nav className="border-b">
+      <ul className="flex flex-wrap items-center gap-1">
+        {tabs.map((t) => {
+          const isActive = t.key === active;
+          const base = "px-3 py-2 text-sm rounded-t";
+          if (t.soon) {
+            return (
+              <li key={t.key}>
+                <span className={`${base} cursor-not-allowed text-gray-400`} title="即将上线">
+                  {t.label}
+                </span>
+              </li>
+            );
+          }
+          return (
+            <li key={t.key}>
+              <Link
+                href={t.href}
+                className={`${base} ${isActive ? "border-b-2 border-black font-medium" : "text-gray-600 hover:text-black"}`}
+              >
+                {t.label}
+              </Link>
+            </li>
+          );
+        })}
+        {/* infra/operator = EOA 轨道，独立入口，非社区 tab */}
+        {roles.operator && (
+          <li className="ml-auto">
+            <Link href="/operator" className="px-3 py-2 text-sm text-gray-500 hover:text-black">
+              运维 · Operator（EOA）
+            </Link>
+          </li>
+        )}
+      </ul>
+      {loading && <p className="px-3 py-1 text-xs text-gray-400">读取角色中…</p>}
+    </nav>
+  );
+}

--- a/aastar-frontend/lib/roles.ts
+++ b/aastar-frontend/lib/roles.ts
@@ -1,0 +1,64 @@
+/**
+ * On-chain role reads (Phase 0 §0.4) — drive the role-gated navigation.
+ *
+ * Reads the connected account's protocol roles from the canonical Registry and
+ * folds them into `RoleFlags`. Pure client-side read (no signing). The nav uses
+ * these to decide which L2 community tabs are visible (owner sees 治理/发币;
+ * members see 任务/商店/投票) — see `components/nav/CommunityNav`.
+ *
+ * @module lib/roles
+ */
+import {
+  ROLE_ANODE,
+  ROLE_COMMUNITY,
+  ROLE_DVT,
+  ROLE_ENDUSER,
+  ROLE_KMS,
+  ROLE_PAYMASTER_AOA,
+  ROLE_PAYMASTER_SUPER,
+  registryActions,
+} from "@aastar/sdk/core";
+import type { Address, Hex } from "viem";
+import { ensureSdkConfig, getPublicClient } from "./sdk/client";
+import { infraAddresses } from "./addresses";
+
+export interface RoleFlags {
+  /** ROLE_COMMUNITY — community owner (sees 治理 / 发币). */
+  community: boolean;
+  /** ROLE_ENDUSER — registered end user. */
+  endUser: boolean;
+  /**
+   * Any infra/operator role (paymaster / DVT / KMS / ANODE). NOTE: infra/operator
+   * flows are the EOA track (jason: infra 参与者本身没有 AirAccount), distinct from
+   * the AirAccount user layer — the nav routes these to the operator area.
+   */
+  operator: boolean;
+  /** Raw role ids held by the account. */
+  roleIds: Hex[];
+}
+
+export const EMPTY_ROLES: RoleFlags = {
+  community: false,
+  endUser: false,
+  operator: false,
+  roleIds: [],
+};
+
+/** Read the account's protocol roles from the canonical Registry. */
+export async function readRoles(user: Address): Promise<RoleFlags> {
+  ensureSdkConfig();
+  const publicClient = getPublicClient();
+  const registry = infraAddresses().registry;
+  // Same `as never` SDK-boundary bridge as lib/community.ts / buildGuardClient.
+  const ext = publicClient.extend(registryActions(registry) as never) as unknown as {
+    getUserRoles: (args: { user: Address }) => Promise<Hex[]>;
+  };
+  const roleIds = await ext.getUserRoles({ user });
+  const has = (r: Hex) => roleIds.some((x) => x.toLowerCase() === r.toLowerCase());
+  return {
+    community: has(ROLE_COMMUNITY),
+    endUser: has(ROLE_ENDUSER),
+    operator: [ROLE_PAYMASTER_AOA, ROLE_PAYMASTER_SUPER, ROLE_DVT, ROLE_KMS, ROLE_ANODE].some(has),
+    roleIds,
+  };
+}


### PR DESCRIPTION
Phase 0 第三批：0.4 GitHub 三层导航。stack 在 master（PR #1/#2 已合）之上。

## 本 PR
- **0.4 导航（仿 GitHub 三层）**：
  - **L1 用户菜单**（跨社区）= 沿用 YAAA 右上用户菜单，不动。
  - **L2 社区菜单** `components/nav/CommunityNav.tsx` = 横向 tab（概览 / MyTask / MyShop / MyVote / 成员 / 治理 / 发币），对所有社区通用，**按链上角色显隐**（治理·发币仅社区 owner）。
  - **L3 模块子导航** = 各模块自己的 sub-nav（进入模块后，本 PR 不含）。
- **EOA 分层落地**：infra/operator（部署 / DVT-register，**EOA 轨道**）不是社区 tab —— 单独「运维·Operator（EOA）」入口，仅账户持 operator 角色时出现。对齐你答的「用户层 AirAccount-only / infra 层 EOA」。
- `lib/roles.ts` — `readRoles(user)` → `RoleFlags`（community/endUser/operator），走 `Registry.getUserRoles`（canonical 地址，`as never` 边界桥接）。
- 挂进 `app/phase0` 验证页演示。

## 本地测试
- `type-check` ✅ · `build -w aastar-frontend` ✅（`/phase0` 静态路由生成）

## 下一阶段 PR #4
后端 `POST /userop/{prepare,submit,status}`（泛化 transfer/*，让 cosSend 真跑通）——写路径的另一半。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
