### PR TITLE
Phase 0 (后端写路径): /userop/* 通用 gasless UserOp (全 tier)

### DIFF
--- a/aastar/src/app.module.ts
+++ b/aastar/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppService } from "./app.service";
 import { AuthModule } from "./auth/auth.module";
 import { AccountModule } from "./account/account.module";
 import { TransferModule } from "./transfer/transfer.module";
+import { UserOpModule } from "./userop/userop.module";
 import { BlsModule } from "./bls/bls.module";
 import { EthereumModule } from "./ethereum/ethereum.module";
 import { DatabaseModule } from "./database/database.module";
@@ -29,6 +30,7 @@ import { SaleModule } from "./sale/sale.module";
     SdkModule, // After DatabaseModule and AuthModule (provides YAAA_SERVER_CLIENT globally)
     AccountModule,
     TransferModule,
+    UserOpModule,
     BlsModule,
     EthereumModule,
     PaymasterModule,

--- a/aastar/src/userop/dto/prepare-userop.dto.ts
+++ b/aastar/src/userop/dto/prepare-userop.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsOptional, IsBoolean, IsEthereumAddress, Matches } from "class-validator";
+
+/**
+ * Phase-1 of a generic gasless UserOp (the `cosSend` write path — see the
+ * frontend `lib/sdk/cosTx.ts`). Unlike the transfer DTO this is a raw contract
+ * call: `{to, data, value}` with no `amount`/`tokenAddress` monetary framing.
+ * The account is resolved server-side from the JWT — never trusted from the body.
+ */
+export class PrepareUserOpDto {
+  @ApiProperty({ description: "Target contract / recipient" })
+  @IsEthereumAddress()
+  to: string;
+
+  @ApiProperty({ description: "Call data (0x-prefixed hex; 0x for a bare value send)" })
+  @IsString()
+  @Matches(/^0x[0-9a-fA-F]*$/, { message: "data must be 0x-prefixed hex" })
+  data: string;
+
+  @ApiProperty({ required: false, description: "Native value in wei (decimal string; default 0)" })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[0-9]+$/, { message: "value must be a decimal wei string" })
+  value?: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Tier-2/3 device-passkey path: skip the KMS owner ceremony (frontend sets it when " +
+      "the account resolves to tier>=2). The SDK rejects it for Tier-1.",
+  })
+  @IsOptional()
+  @IsBoolean()
+  useWebAuthnPasskey?: boolean;
+
+  @ApiProperty({ required: false, description: "Sponsor gas (default true — Cos72 is gasless-only)" })
+  @IsOptional()
+  @IsBoolean()
+  usePaymaster?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  paymasterAddress?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  paymasterData?: string;
+}

--- a/aastar/src/userop/dto/submit-userop.dto.ts
+++ b/aastar/src/userop/dto/submit-userop.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsObject, IsOptional, Matches } from "class-validator";
+import { DeviceWebAuthnDto } from "../../transfer/dto/submit-transfer.dto";
+
+/**
+ * Phase-3 of a generic gasless UserOp. Same two mutually-exclusive completion
+ * paths as a transfer (the SDK decides by tier):
+ *  - Tier-1 (KMS owner ceremony): `challengeId` + `credential`.
+ *  - Tier-2/3 (WebAuthn passkey): `deviceWebAuthn` (challenge = userOpHash).
+ * Plus an optional Tier-3 `guardianSignature`. `opId` is the prepared handle.
+ */
+export class SubmitUserOpDto {
+  @ApiProperty({ description: "Opaque handle returned by /userop/prepare" })
+  @IsString()
+  opId: string;
+
+  @ApiProperty({ required: false, description: "Tier-1 KMS ceremony ChallengeId" })
+  @IsOptional()
+  @IsString()
+  challengeId?: string;
+
+  @ApiProperty({ required: false, description: "Tier-1 KMS ceremony WebAuthn credential" })
+  @IsOptional()
+  @IsObject()
+  credential?: unknown;
+
+  @ApiProperty({ required: false, type: DeviceWebAuthnDto, description: "Tier-2/3 passkey assertion" })
+  @IsOptional()
+  @IsObject()
+  deviceWebAuthn?: DeviceWebAuthnDto;
+
+  @ApiProperty({ required: false, description: "Tier-3 guardian co-signature (hex) over userOpHash" })
+  @IsOptional()
+  @IsString()
+  @Matches(/^0x[0-9a-fA-F]+$/, { message: "guardianSignature must be a 0x-prefixed hex string" })
+  guardianSignature?: string;
+}

--- a/aastar/src/userop/userop.controller.ts
+++ b/aastar/src/userop/userop.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Post, Get, Body, Param, UseGuards, Request } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { UserOpService } from "./userop.service";
+import { PrepareUserOpDto } from "./dto/prepare-userop.dto";
+import { SubmitUserOpDto } from "./dto/submit-userop.dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+
+/**
+ * Generic gasless UserOp endpoints — the backend contract `cosSend` calls
+ * (`aastar-frontend/lib/api.ts` userOpAPI). Account is resolved from the JWT.
+ */
+@ApiTags("userop")
+@Controller("userop")
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class UserOpController {
+  constructor(private userOpService: UserOpService) {}
+
+  @Post("prepare")
+  @ApiOperation({ summary: "Phase 1: prepare a sponsored UserOp for an arbitrary call" })
+  async prepare(@Request() req, @Body() dto: PrepareUserOpDto) {
+    return this.userOpService.prepare(req.user.sub, dto);
+  }
+
+  @Post("submit")
+  @ApiOperation({ summary: "Phase 3: submit a prepared UserOp with the ceremony assertion" })
+  async submit(@Request() req, @Body() dto: SubmitUserOpDto) {
+    return this.userOpService.submit(req.user.sub, dto);
+  }
+
+  @Get("status/:id")
+  @ApiOperation({ summary: "Poll a UserOp's status (transactionHash appears when landed)" })
+  async status(@Request() req, @Param("id") id: string) {
+    return this.userOpService.getStatus(req.user.sub, id);
+  }
+}

--- a/aastar/src/userop/userop.module.ts
+++ b/aastar/src/userop/userop.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { UserOpService } from "./userop.service";
+import { UserOpController } from "./userop.controller";
+
+// YAAA_SERVER_CLIENT + ConfigService are global providers (SdkModule / ConfigModule),
+// so no imports are needed here — mirrors TransferModule.
+@Module({
+  providers: [UserOpService],
+  controllers: [UserOpController],
+})
+export class UserOpModule {}

--- a/aastar/src/userop/userop.service.ts
+++ b/aastar/src/userop/userop.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Inject, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  AirAccountServerClient as YAAAServerClient,
+  DvtPendingConfirmationError,
+} from "@aastar/sdk/kms";
+import { getCanonicalAddresses } from "@aastar/sdk/core";
+import { formatEther } from "viem";
+import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
+import { PrepareUserOpDto } from "./dto/prepare-userop.dto";
+import { SubmitUserOpDto } from "./dto/submit-userop.dto";
+
+/**
+ * Generic gasless UserOp — the backend half of `cosSend` (frontend
+ * `lib/sdk/cosTx.ts`). A thin passthrough to the same shared
+ * `YAAA_SERVER_CLIENT.transfers.*` the transfer flow uses: the SDK's transfer
+ * path is already a raw `AirAccount.execute(to, value, data)` call when no token
+ * is given, so an arbitrary contract call reuses it verbatim. Tier logic /
+ * KMS / BLS / guardian / bundler all live in the SDK — this only maps the DTO
+ * and drops the transfer-specific bits (token auto-encode, address book).
+ *
+ * ALL tiers are supported (same two ceremony paths as transfer): Tier-1 KMS
+ * owner ceremony (`challengeId`+`credential`) and Tier-2/3 WebAuthn passkey
+ * (`deviceWebAuthn`), plus Tier-3 guardian co-sign. The account is resolved
+ * from the JWT `userId` inside the SDK — never from the request body.
+ */
+@Injectable()
+export class UserOpService {
+  private readonly logger = new Logger(UserOpService.name);
+
+  constructor(
+    @Inject(YAAA_SERVER_CLIENT) private client: YAAAServerClient,
+    private configService: ConfigService
+  ) {}
+
+  async prepare(userId: string, dto: PrepareUserOpDto) {
+    // cosSend sends `value` in wei; the SDK's `amount` is an ETH-string it
+    // parseEther()s back to wei — convert so the round-trip is exact.
+    const amount = dto.value ? formatEther(BigInt(dto.value)) : "0";
+    const paymasterTokenAddress = this.resolvePaymasterToken(dto.paymasterAddress);
+    this.logger.log(`userop.prepare: userId=${userId} to=${dto.to} value=${dto.value ?? "0"}`);
+    const prep = await this.client.transfers.prepareTransfer(userId, {
+      to: dto.to,
+      amount,
+      data: dto.data,
+      usePaymaster: dto.usePaymaster !== false, // gasless-only: default on
+      paymasterAddress: dto.paymasterAddress,
+      paymasterData: dto.paymasterData,
+      paymasterTokenAddress,
+      useAirAccountTiering: true,
+      useWebAuthnPasskey: dto.useWebAuthnPasskey === true,
+    });
+    return {
+      opId: prep.transferId,
+      userOpHash: prep.userOpHash,
+      challengeId: prep.challengeId,
+      publicKeyOptions: prep.publicKeyOptions,
+      tier: prep.tier,
+      requiredSigs: prep.requiredSigs,
+    };
+  }
+
+  async submit(userId: string, dto: SubmitUserOpDto) {
+    const guardianSigner = dto.guardianSignature
+      ? { signMessage: async () => dto.guardianSignature as string }
+      : undefined;
+    this.logger.log(`userop.submit: userId=${userId} opId=${dto.opId}`);
+    try {
+      if (dto.deviceWebAuthn) {
+        return await this.client.transfers.submitPreparedTransfer(userId, {
+          transferId: dto.opId,
+          deviceWebAuthn: {
+            authenticatorData: dto.deviceWebAuthn.authenticatorData as `0x${string}`,
+            clientDataJSON: dto.deviceWebAuthn.clientDataJSON,
+            signature: dto.deviceWebAuthn.signature as `0x${string}`,
+          },
+          ...(guardianSigner ? { guardianSigner } : {}),
+        });
+      }
+      return await this.client.transfers.submitPreparedTransfer(userId, {
+        transferId: dto.opId,
+        webAuthnAssertion: { ChallengeId: dto.challengeId, Credential: dto.credential },
+        ...(guardianSigner ? { guardianSigner } : {}),
+      });
+    } catch (err: any) {
+      // Scheme-2: DVT withheld its co-sig pending out-of-band approval — return a
+      // structured pending payload so the client drives the confirmation + resubmits.
+      if (err instanceof DvtPendingConfirmationError) {
+        return {
+          success: false,
+          pendingConfirmation: true,
+          userOpHash: err.userOpHash,
+          nodeEndpoint: err.nodeEndpoint,
+        };
+      }
+      this.logger.error(`userop.submit FAILED: ${err?.message ?? err}`, err?.stack);
+      throw err;
+    }
+  }
+
+  /** Poll target for the client (cosSend polls until `transactionHash` appears). */
+  async getStatus(userId: string, id: string) {
+    return this.client.transfers.getTransferStatus(userId, id);
+  }
+
+  /** PMv4 gas-token: same canonical resolution as TransferService (undefined unless PMv4). */
+  private resolvePaymasterToken(paymasterAddress?: string): string | undefined {
+    const canonical = getCanonicalAddresses(this.configService.get<number>("chainId") ?? 11155111);
+    return canonical && paymasterAddress?.toLowerCase() === canonical.paymasterV4?.toLowerCase()
+      ? canonical.aPNTs
+      : undefined;
+  }
+}


### PR DESCRIPTION
Phase 0 第四批：后端 `/userop/*`（cosSend 的另一半）。写路径的后端。

## 本 PR（纯后端 `aastar` workspace）
- `src/userop/{userop.controller,userop.service,userop.module}.ts` + `dto/{prepare,submit}-userop.dto.ts`
- **通用 gasless UserOp**：把转账流程泛化成任意合约调用 `{to, data, value}`。复用**同一个** `YAAA_SERVER_CLIENT.transfers.*`——SDK 的转账路径在没传 token 时**本来就是** `AirAccount.execute(to, value, data)`，所以任意调用直接复用，**不改 SDK**。
- **全 tier**（回应上一轮：不是限制 T2/3）：passthrough 两条 ceremony 路径都收——**T1 KMS owner ceremony**（`challengeId`+`credential`）/ **T2-3 WebAuthn passkey**（`deviceWebAuthn`）/ **T3 guardian** co-sign / **DVT-pending** 重提，与转账流完全一致。
- 砍掉转账专属：token 便捷编码 + 地址簿副作用；`value` wei→ETH-string（`formatEther`，因 SDK `amount` 是 ETH 单位）；复用 schemaless `transfers` 表（`opId`=transferId），无新 entity。
- 账户由 **JWT `userId`** 解析（SDK 内部），**绝不信** body 传的地址；`usePaymaster` 默认开（gasless-only）。

## 本地测试
- 后端 `type-check -w aastar` ✅ · `build -w aastar` ✅（`dist/userop` 全编译）

## 下一阶段 PR #5（前端）
cosSend 全 tier 统一（复刻转账页 tier 分支：`!publicKeyOptions` 分 T1/T2-3 + guardian + DVT-pending）+ **轮询** `/userop/status` 拿 txHash + api/session 接线。写路径两半合齐即可跑。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
