### PR TITLE
Phase 0 (前端写路径): cosSend 全 tier 统一 + 轮询

### DIFF
--- a/aastar-frontend/contexts/Cos72SessionContext.tsx
+++ b/aastar-frontend/contexts/Cos72SessionContext.tsx
@@ -17,7 +17,6 @@ import type { ReactNode } from "react";
 import type { Address, Hash } from "viem";
 import { accountAPI } from "@/lib/api";
 import { isAuthenticated } from "@/lib/auth";
-import { assertUserOpHash } from "@/lib/webauthn-assert";
 import { cosSend, type ContractCall } from "@/lib/sdk/cosTx";
 
 interface Cos72Session {
@@ -58,8 +57,15 @@ export function Cos72SessionProvider({ children }: { children: ReactNode }) {
     void refresh();
   }, [refresh]);
 
-  // Gasless write: cosSend handles encode → backend prepare → passkey assert → submit.
-  const send = useCallback((call: ContractCall) => cosSend(call, assertUserOpHash), []);
+  // Gasless write: cosSend runs the full multi-tier flow (resolve tier → prepare →
+  // ceremony → submit → DVT-pending → poll txHash). Needs the AirAccount address.
+  const send = useCallback(
+    (call: ContractCall) => {
+      if (!address) throw new Error("Not connected — passkey login required.");
+      return cosSend(call, address);
+    },
+    [address]
+  );
 
   return (
     <Cos72SessionCtx.Provider

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -39,11 +39,38 @@ api.interceptors.response.use(
 // TODO(backend): implement POST /userop/{prepare,submit,status} in NestJS by generalizing
 // the existing transfer/* flow to an arbitrary { to, data, value } call.
 export const userOpAPI = {
-  prepare: (data: { to: string; data: string; value?: string; accountAddress?: string }) =>
-    api.post<{ opId: string; userOpHash: string }>("/userop/prepare", data),
-  submit: (data: { opId: string; deviceWebAuthn?: unknown; guardianSignature?: string }) =>
-    api.post<{ txHash: string }>("/userop/submit", data),
-  getStatus: (id: string) => api.get(`/userop/status/${id}`),
+  prepare: (data: {
+    to: string;
+    data: string;
+    value?: string;
+    useWebAuthnPasskey?: boolean;
+    paymasterAddress?: string;
+  }) =>
+    api.post<{
+      opId: string;
+      userOpHash: string;
+      challengeId?: string;
+      publicKeyOptions?: unknown; // present iff Tier-1 KMS ceremony
+      tier?: number | null;
+      requiredSigs?: { bls?: number; guardian?: number };
+    }>("/userop/prepare", data),
+  submit: (data: {
+    opId: string;
+    deviceWebAuthn?: unknown; // Tier-2/3 WebAuthn path
+    challengeId?: string; // Tier-1 KMS path
+    credential?: unknown; // Tier-1 KMS path
+    guardianSignature?: string; // Tier-3
+  }) =>
+    api.post<{
+      success?: boolean;
+      pendingConfirmation?: boolean; // Scheme-2 DVT withhold
+      userOpHash?: string;
+      nodeEndpoint?: string;
+      transferId?: string;
+      transactionHash?: string;
+    }>("/userop/submit", data),
+  getStatus: (id: string) =>
+    api.get<{ status?: string; transactionHash?: string; error?: string }>(`/userop/status/${id}`),
 };
 
 // Auth API

--- a/aastar-frontend/lib/sdk/cosTx.ts
+++ b/aastar-frontend/lib/sdk/cosTx.ts
@@ -2,18 +2,27 @@
  * cosSend / cosRead — Cos72's single gasless write + read path (Phase 0 §0.2).
  *
  * Cos72 is AirAccount-only (no `window.ethereum`, no EOA). Every module write
- * that used to call `walletClient.writeContract(...)` goes through `cosSend`:
- * because KMS is server-only, the write is prepared + submitted by the backend
- * (sponsored UserOp via SuperPaymaster), and the browser only produces a passkey
- * (WebAuthn) assertion over the prepared `userOpHash`. Reads use a public client
- * over the user-configured RPC (`config/brand.ts` / Settings), no signing.
+ * that used to call `walletClient.writeContract(...)` goes through `cosSend`.
+ * Because KMS is server-only, the sponsored UserOp is prepared + submitted by the
+ * backend (`/userop/*`); the browser only runs the tier-appropriate passkey
+ * ceremony. This mirrors, 1:1, the proven transfer flow (`app/transfer/page.tsx`)
+ * — ALL tiers: Tier-1 KMS owner ceremony, Tier-2/3 device-passkey, Tier-3 guardian
+ * co-sign, and the Scheme-2 DVT out-of-band confirmation. Reads use a public
+ * client over the user-configured RPC, no signing.
  *
  * @module lib/sdk/cosTx
  */
 import { encodeFunctionData } from "viem";
 import type { Abi, Address, Hash, Hex } from "viem";
+import { startAuthentication } from "@simplewebauthn/browser";
+import { resolveTransfer } from "@aastar/sdk/airaccount";
 import { ensureSdkConfig, getPublicClient } from "./client";
 import { userOpAPI } from "@/lib/api";
+import {
+  assertUserOpHash,
+  collectGuardianSignature,
+  runDvtConfirmation,
+} from "@/lib/webauthn-assert";
 
 /** A single contract call — the unit every module hands to cosSend/cosRead. */
 export interface ContractCall {
@@ -24,14 +33,6 @@ export interface ContractCall {
   /** Native value (wei) for payable calls. */
   value?: bigint;
 }
-
-/**
- * Produce a passkey (WebAuthn) assertion whose challenge = the prepared
- * `userOpHash`. Supplied by the session layer (§0.1) so cosSend stays
- * transport-agnostic and testable. Returns whatever the backend `submit`
- * endpoint expects as `deviceWebAuthn`.
- */
-export type SignUserOpHash = (userOpHash: Hex) => Promise<unknown>;
 
 /** Read a contract via a public client (brand.ts RPC). No account, no signing. */
 export async function cosRead<T = unknown>(
@@ -47,35 +48,93 @@ export async function cosRead<T = unknown>(
   }) as Promise<T>;
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 /**
- * Gasless write. Encodes the call → backend prepares a sponsored UserOp and
- * returns its `userOpHash` → the browser signs that hash via passkey → backend
- * submits (KMS/BLS-signs + bundler). Returns the on-chain tx hash.
- *
- * This is the one place module writes converge; swapping the sponsorship/bundler
- * strategy later is a backend concern, invisible to callers.
+ * Gasless write, all tiers. Resolves the account's tier, prepares a sponsored
+ * UserOp on the backend, runs the tier-appropriate ceremony, submits, handles a
+ * DVT out-of-band withhold, then polls for the on-chain tx hash. Replaces every
+ * module's `walletClient.writeContract(...)`.
  *
  * SECURITY — trust boundary (PR #1 review note 1): the passkey signs
- * `prepared.userOpHash` exactly as the backend returned it. The browser cannot
- * independently recompute that hash (it lacks the fully-assembled sponsored op),
- * so the signature's binding to `{to,data,value}` is only as trustworthy as the
- * backend. This is inherent to the KMS-server-only / backend-prepares-the-UserOp
- * model and acceptable for AirAccount-only with our own backend. Future
- * hardening: have `prepare` echo the decoded op for the user to confirm before
- * the passkey ceremony.
+ * `prep.userOpHash` (Tier-2/3) or the SDK-computed commitment (Tier-1) exactly as
+ * the backend returned it. The browser cannot independently recompute the hash
+ * (it lacks the assembled op), so the binding to `{to,data,value}` is only as
+ * trustworthy as the backend. Inherent to the KMS-server-only model; acceptable
+ * for AirAccount-only with our own backend. Future hardening: echo the decoded op
+ * for the user to confirm before the ceremony.
  */
-export async function cosSend(call: ContractCall, sign: SignUserOpHash): Promise<Hash> {
+export async function cosSend(call: ContractCall, account: Address): Promise<Hash> {
+  ensureSdkConfig();
+  const publicClient = getPublicClient();
   const data = encodeFunctionData({
     abi: call.abi,
     functionName: call.functionName,
     args: call.args as unknown[] | undefined,
   });
-  const { data: prepared } = await userOpAPI.prepare({
+  const value = call.value ?? 0n;
+
+  // 1) Resolve the tier client-side (same as the transfer page) to pick the path.
+  let tier: number | null = null;
+  try {
+    const res = await resolveTransfer({
+      client: publicClient as never,
+      account,
+      amount: value,
+      token: "ETH",
+    });
+    tier = res.tier;
+  } catch {
+    /* keep null → Tier-1 KMS ceremony path */
+  }
+  const useWebAuthnPasskey = (tier ?? 1) >= 2;
+
+  // 2) Prepare the sponsored UserOp.
+  const { data: prep } = await userOpAPI.prepare({
     to: call.to,
     data,
-    value: call.value?.toString(),
+    value: value.toString(),
+    useWebAuthnPasskey,
   });
-  const deviceWebAuthn = await sign(prepared.userOpHash as Hex);
-  const { data: submitted } = await userOpAPI.submit({ opId: prepared.opId, deviceWebAuthn });
-  return submitted.txHash as Hash;
+
+  // 3) Ceremony — branch on whether the SDK returned a KMS commitment.
+  const isWebAuthnPath = !prep.publicKeyOptions;
+  let deviceWebAuthn: unknown;
+  let credential: unknown;
+  if (isWebAuthnPath) {
+    deviceWebAuthn = await assertUserOpHash(prep.userOpHash as Hex);
+  } else {
+    // Tier-1 KMS owner ceremony: sign the SDK-computed commitment verbatim.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    credential = await startAuthentication({ optionsJSON: prep.publicKeyOptions as any });
+  }
+
+  // 4) Tier-3 guardian co-sign over the userOpHash.
+  let guardianSignature: string | undefined;
+  if ((prep.requiredSigs?.guardian ?? 0) > 0) {
+    guardianSignature = await collectGuardianSignature(prep.userOpHash as Hex);
+  }
+
+  // 5) Submit (payload discriminated by path).
+  const submitPayload = isWebAuthnPath
+    ? { opId: prep.opId, deviceWebAuthn, guardianSignature }
+    : { opId: prep.opId, challengeId: prep.challengeId, credential, guardianSignature };
+  let { data: res } = await userOpAPI.submit(submitPayload);
+
+  // 6) Scheme-2: DVT withheld its co-sig → approve out-of-band + resubmit.
+  if (res?.pendingConfirmation && res.userOpHash && res.nodeEndpoint) {
+    const ok = await runDvtConfirmation(res.userOpHash, res.nodeEndpoint);
+    if (!ok) throw new Error("Out-of-band confirmation was rejected or expired.");
+    ({ data: res } = await userOpAPI.submit(submitPayload));
+  }
+
+  // 7) Poll status for the on-chain tx hash (submit returns pending; op lands async).
+  if (res?.transactionHash) return res.transactionHash as Hash;
+  for (let i = 0; i < 60; i++) {
+    await sleep(2000);
+    const { data: st } = await userOpAPI.getStatus(prep.opId);
+    if (st?.transactionHash) return st.transactionHash as Hash;
+    if (st?.status === "failed") throw new Error(`UserOp failed${st.error ? ": " + st.error : ""}`);
+  }
+  throw new Error("UserOp timed out waiting for transactionHash");
 }

--- a/aastar-frontend/lib/webauthn-assert.ts
+++ b/aastar-frontend/lib/webauthn-assert.ts
@@ -13,7 +13,8 @@
  * @module lib/webauthn-assert
  */
 import { startAuthentication } from "@simplewebauthn/browser";
-import type { Hex } from "viem";
+import { createWalletClient, custom, type Address, type Hex } from "viem";
+import { confirmationCredentialRequest, submitDvtConfirmation } from "@aastar/sdk/airaccount";
 import { webauthnRpId } from "@/lib/webauthn-rp";
 
 export type DeviceWebAuthn = {
@@ -70,4 +71,58 @@ export async function assertUserOpHash(userOpHash: Hex): Promise<DeviceWebAuthn>
     clientDataJSON: new TextDecoder().decode(b64urlToBytes(r.clientDataJSON)),
     signature: bytesToHex(b64urlToBytes(r.signature)),
   };
+}
+
+/**
+ * Tier-3 only: collect a guardian co-signature over the prepared userOpHash from
+ * the user's self-hosted guardian wallet (injected EIP-1193). `signMessage({raw})`
+ * is eth-prefixed, matching the SDK GuardianSigner the backend wraps it in. The
+ * guardian is a separate infra-ish co-signer — this is the one place a user-layer
+ * op touches an injected wallet, and only for high-value Tier-3.
+ */
+export async function collectGuardianSignature(userOpHash: Hex): Promise<string> {
+  const eth =
+    typeof window === "undefined"
+      ? undefined
+      : (
+          window as unknown as {
+            ethereum?: { request: (a: { method: string; params?: unknown[] }) => Promise<unknown> };
+          }
+        ).ethereum;
+  if (!eth) {
+    throw new Error("A guardian wallet (e.g. MetaMask) is required to co-sign a Tier-3 op.");
+  }
+  const accounts = (await eth.request({ method: "eth_requestAccounts" })) as Address[];
+  if (!accounts?.length) throw new Error("No guardian account available to co-sign.");
+  const wallet = createWalletClient({ transport: custom(eth) });
+  return wallet.signMessage({ account: accounts[0], message: { raw: userOpHash } });
+}
+
+/**
+ * Scheme-2 out-of-band DVT approval: when a high-value op is withheld (backend
+ * returns pendingConfirmation), the owner approves by signing the userOpHash with
+ * the device passkey and POSTing the assertion to the withholding node, which then
+ * releases its co-signature so the op can be resubmitted.
+ */
+export async function runDvtConfirmation(
+  userOpHash: string,
+  nodeEndpoint: string
+): Promise<boolean> {
+  const req = confirmationCredentialRequest(userOpHash, { rpId: webauthnRpId() });
+  const assertion = await startAuthentication({
+    optionsJSON: {
+      challenge: bufToB64url(req.challenge),
+      rpId: req.rpId,
+      userVerification: req.userVerification,
+      timeout: req.timeout,
+      allowCredentials: (req.allowCredentials ?? []).map((c) => ({
+        id: bufToB64url(c.id as ArrayBuffer),
+        type: "public-key" as const,
+      })),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r = await submitDvtConfirmation(nodeEndpoint, userOpHash, assertion as any);
+  return r.confirmed;
 }


### PR DESCRIPTION
Phase 0 第五批：cosSend 全 tier 统一 + 轮询。与 PR #4 后端合齐 = **写路径真能跑**。

## 本 PR（前端）
- **`cosSend` 重写为全 tier**（1:1 复刻 `app/transfer/page.tsx` 的 tier 流，回应上一轮纠正——不是只 T2/3）：
  1. `resolveTransfer` 定 tier → `useWebAuthnPasskey = tier>=2`
  2. `/userop/prepare` → `!publicKeyOptions` 分岔：**T1** KMS ceremony（`startAuthentication(publicKeyOptions)` → credential）/ **T2-3** device-passkey（`assertUserOpHash(userOpHash)` → deviceWebAuthn）
  3. **T3** guardian co-sign（`requiredSigs.guardian>0`）
  4. `/userop/submit`（payload 按路径判别）
  5. **DVT-pending** → `runDvtConfirmation` → 重提
  6. **轮询** `/userop/status` 拿 `transactionHash`（submit 返 pending，op 异步上链）
- `lib/webauthn-assert.ts`：抽出 `collectGuardianSignature` + `runDvtConfirmation`（转账页复用，`@aastar/sdk/airaccount`）。
- `userOpAPI`：prepare 返回全 tier 字段、submit 收两条路 + guardian、status 带 txHash。
- `session.send` = `cosSend(call, address)`，去掉 sign 回调，全 tier 自包含。
- 保留 PR #1 review 的信任边界注释。

## 本地测试
- `type-check -w aastar-frontend` ✅ · `build -w aastar-frontend` ✅（`/phase0` 静态路由）

## 合齐后
PR #4（后端 `/userop/*`）+ 本 PR = cosSend 端到端可写（全 tier / gasless / passkey）。**Phase 0 共享层完成**：0.0 SDK / 0.1 会话 / 0.2 写路径 / 0.3 地址 / 0.4 导航 / 0.5 社区。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
