### PR TITLE
fix: /phase0 演示页套进 YAA Layout + 样式

### DIFF
--- a/aastar-frontend/app/phase0/page.tsx
+++ b/aastar-frontend/app/phase0/page.tsx
@@ -1,57 +1,82 @@
 /**
- * Phase 0 verification page (§DoD).
- *
- * Exercises the shared layer end-to-end, client-side, with no module business
- * logic: 0.1 session (AirAccount address), 0.3 canonical infra addresses, 0.5
- * community xPNTs credibility read. The gasless write path (cosSend) needs the
- * backend `/userop/*` endpoints (next stage) so it's not exercised here.
+ * Phase 0 verification page (§DoD) — rendered inside YAA's real app shell
+ * (`<Layout>` + design system), exercising the shared layer end-to-end:
+ * 0.1 session, 0.3 canonical infra addresses, 0.4 role-gated nav, 0.5 credibility.
+ * No module business logic; the write path (cosSend) needs the backend `/userop/*`.
  */
 "use client";
 
 import { useState } from "react";
 import { formatUnits } from "viem";
 import type { Address } from "viem";
+import Layout from "@/components/Layout";
 import { Cos72SessionProvider, useCos72Session } from "@/contexts/Cos72SessionContext";
 import { CommunityNav } from "@/components/nav/CommunityNav";
 import { infraAddresses } from "@/lib/addresses";
 import { listCommunityTokens, readCredibility, type Credibility } from "@/lib/community";
 
+const CARD =
+  "bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5";
+const H2 = "text-sm font-semibold text-gray-900 dark:text-white mb-3";
+
 function SessionPanel() {
   const { address, isConnected, isLoading } = useCos72Session();
   return (
-    <section className="rounded-lg border p-4">
-      <h2 className="mb-2 font-semibold">0.1 统一会话（AirAccount-only）</h2>
+    <section className={CARD}>
+      <h2 className={H2}>0.1 统一会话（AirAccount-only）</h2>
       {isLoading ? (
-        <p className="text-sm text-gray-500">加载中…</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">加载中…</p>
       ) : isConnected ? (
-        <p className="text-sm">
-          已登录 · AirAccount 地址：<code className="break-all">{address ?? "（无账户，去建号）"}</code>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          已登录 · AirAccount 地址：
+          <code className="font-mono break-all text-emerald-600 dark:text-emerald-400">
+            {address ?? "（无账户，去建号）"}
+          </code>
         </p>
       ) : (
-        <p className="text-sm text-gray-500">未登录（passkey 登录后显示 AirAccount 地址）</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          未登录（passkey 登录后显示 AirAccount 地址）
+        </p>
       )}
     </section>
   );
 }
 
+function NavPanel() {
+  return (
+    <section className={CARD}>
+      <h2 className={H2}>0.4 社区导航（L2，仿 GitHub，按链上角色显隐）</h2>
+      <CommunityNav active="overview" />
+      <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+        治理 / 发币仅社区 owner 可见；运维·Operator（EOA 轨道）仅持 operator 角色可见。
+      </p>
+    </section>
+  );
+}
+
 function AddressPanel() {
-  let addrs: Record<string, Address>;
+  let addrs: Record<string, Address> | null = null;
+  let err: string | null = null;
   try {
     addrs = infraAddresses() as unknown as Record<string, Address>;
   } catch (e) {
-    return <p className="text-sm text-red-600">地址解析失败：{String(e)}</p>;
+    err = String(e);
   }
   return (
-    <section className="rounded-lg border p-4">
-      <h2 className="mb-2 font-semibold">0.3 canonical 地址（来自 @aastar/sdk）</h2>
-      <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
-        {Object.entries(addrs).map(([k, v]) => (
-          <div key={k}>
-            <span className="text-gray-500">{k}: </span>
-            <code className="break-all">{v}</code>
-          </div>
-        ))}
-      </div>
+    <section className={CARD}>
+      <h2 className={H2}>0.3 canonical 地址（来自 @aastar/sdk）</h2>
+      {err ? (
+        <p className="text-sm text-red-600 dark:text-red-400">地址解析失败：{err}</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+          {Object.entries(addrs!).map(([k, v]) => (
+            <div key={k} className="text-xs">
+              <span className="text-gray-500 dark:text-gray-400">{k}: </span>
+              <code className="font-mono break-all text-gray-700 dark:text-gray-300">{v}</code>
+            </div>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -78,26 +103,31 @@ function CredibilityPanel() {
   }
 
   return (
-    <section className="rounded-lg border p-4">
-      <h2 className="mb-2 font-semibold">0.5 社区 xPNTs 可信度</h2>
+    <section className={CARD}>
+      <h2 className={H2}>0.5 社区 xPNTs 可信度</h2>
       <button
         onClick={load}
         disabled={loading}
-        className="mb-3 rounded bg-black px-3 py-1 text-sm text-white disabled:opacity-50"
+        className="mb-3 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
       >
         {loading ? "读取中…" : "读取社区 xPNTs 可信度"}
       </button>
-      {err && <p className="text-sm text-red-600">读取失败（需已配置 RPC）：{err}</p>}
+      {err && (
+        <p className="text-sm text-red-600 dark:text-red-400">读取失败（需已配置 RPC）：{err}</p>
+      )}
       {rows.map(({ token, cred }) => (
-        <div key={token} className="mb-2 border-t pt-2 text-xs">
-          <div>
-            <code className="break-all">{token}</code>
-          </div>
-          <div>
+        <div
+          key={token}
+          className="mt-2 border-t border-gray-100 pt-2 text-xs dark:border-gray-700"
+        >
+          <code className="font-mono break-all text-gray-700 dark:text-gray-300">{token}</code>
+          <div className="mt-1 text-gray-700 dark:text-gray-300">
             可信度：<b>{cred.credibilityScore}</b>/100
-            {cred.isOverIssued && <span className="ml-2 text-red-600">⚠ 已超发</span>}
+            {cred.isOverIssued && (
+              <span className="ml-2 text-red-600 dark:text-red-400">⚠ 已超发</span>
+            )}
           </div>
-          <div className="text-gray-500">
+          <div className="text-gray-500 dark:text-gray-400">
             发行 ${formatUnits(cred.issuedValueUSD, 18)} · 背书 ${formatUnits(cred.backingValueUSD, 18)}{" "}
             · 上限 ${formatUnits(cred.effectiveCapUSD, 18)}
           </div>
@@ -109,23 +139,23 @@ function CredibilityPanel() {
 
 export default function Phase0Page() {
   return (
-    <Cos72SessionProvider>
-      <main className="mx-auto max-w-2xl space-y-4 p-6">
-        <h1 className="text-xl font-bold">Cos72 Phase 0 — 共享层验证</h1>
-        <p className="text-sm text-gray-500">
-          验证会话 / canonical 地址 / 社区可信度 / 角色导航。写路径（cosSend）待后端 /userop 上线。
-        </p>
-        <section className="rounded-lg border p-4">
-          <h2 className="mb-2 font-semibold">0.4 社区导航（L2，按链上角色显隐）</h2>
-          <CommunityNav active="overview" />
-          <p className="mt-2 text-xs text-gray-400">
-            治理 / 发币仅社区 owner 可见；运维·Operator（EOA 轨道）仅持 operator 角色可见。
-          </p>
-        </section>
-        <SessionPanel />
-        <AddressPanel />
-        <CredibilityPanel />
-      </main>
-    </Cos72SessionProvider>
+    <Layout>
+      <Cos72SessionProvider>
+        <div className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Cos72 Phase 0 — 共享集成层
+            </h1>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              会话 / canonical 地址 / 角色导航 / 社区可信度。写路径（cosSend）待后端 /userop 部署。
+            </p>
+          </div>
+          <NavPanel />
+          <SessionPanel />
+          <AddressPanel />
+          <CredibilityPanel />
+        </div>
+      </Cos72SessionProvider>
+    </Layout>
   );
 }

--- a/aastar-frontend/components/nav/CommunityNav.tsx
+++ b/aastar-frontend/components/nav/CommunityNav.tsx
@@ -67,15 +67,18 @@ export function CommunityNav({ active }: { active?: string }) {
   const tabs = TABS.filter((t) => !t.ownerOnly || roles.community);
 
   return (
-    <nav className="border-b">
+    <nav className="border-b border-gray-200 dark:border-gray-700">
       <ul className="flex flex-wrap items-center gap-1">
         {tabs.map((t) => {
           const isActive = t.key === active;
-          const base = "px-3 py-2 text-sm rounded-t";
+          const base = "px-3 py-2 text-sm rounded-t transition-colors";
           if (t.soon) {
             return (
               <li key={t.key}>
-                <span className={`${base} cursor-not-allowed text-gray-400`} title="即将上线">
+                <span
+                  className={`${base} cursor-not-allowed text-gray-400 dark:text-gray-500`}
+                  title="即将上线"
+                >
                   {t.label}
                 </span>
               </li>
@@ -85,7 +88,11 @@ export function CommunityNav({ active }: { active?: string }) {
             <li key={t.key}>
               <Link
                 href={t.href}
-                className={`${base} ${isActive ? "border-b-2 border-black font-medium" : "text-gray-600 hover:text-black"}`}
+                className={`${base} ${
+                  isActive
+                    ? "border-b-2 border-emerald-500 font-medium text-gray-900 dark:text-white"
+                    : "text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+                }`}
               >
                 {t.label}
               </Link>
@@ -95,13 +102,18 @@ export function CommunityNav({ active }: { active?: string }) {
         {/* infra/operator = EOA 轨道，独立入口，非社区 tab */}
         {roles.operator && (
           <li className="ml-auto">
-            <Link href="/operator" className="px-3 py-2 text-sm text-gray-500 hover:text-black">
+            <Link
+              href="/operator"
+              className="px-3 py-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
               运维 · Operator（EOA）
             </Link>
           </li>
         )}
       </ul>
-      {loading && <p className="px-3 py-1 text-xs text-gray-400">读取角色中…</p>}
+      {loading && (
+        <p className="px-3 py-1 text-xs text-gray-400 dark:text-gray-500">读取角色中…</p>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
/phase0 演示页从裸文字改成套进 YAA 的 Layout + 卡片样式(暗色感知)。CommunityNav 配色也改暗色感知。

澄清: /phase0 只是 Phase0 底层管道的验证页; cos72 是 YAA fork, 全部成熟页面(dashboard/transfer/tasks/operator)原封不动继承。真正在 YAA 成熟页面上接新逻辑是 Phase 1(app/tasks 换 cosSend)。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
