### PR TITLE
feat(phase1): MyTask 写路径全部走 cosSend gasless

### DIFF
--- a/aastar-frontend/app/layout.tsx
+++ b/aastar-frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/lib/theme";
 import { DashboardProvider } from "@/contexts/DashboardContext";
+import { Cos72SessionProvider } from "@/contexts/Cos72SessionContext";
 import { TaskProvider } from "@/contexts/TaskContext";
 import I18nProvider from "@/lib/i18n/I18nProvider";
 
@@ -50,10 +51,12 @@ export default function RootLayout({
         <I18nProvider>
           <ThemeProvider>
             <DashboardProvider>
-              <TaskProvider>
-                {children}
-                <Toaster position="top-right" />
-              </TaskProvider>
+              <Cos72SessionProvider>
+                <TaskProvider>
+                  {children}
+                  <Toaster position="top-right" />
+                </TaskProvider>
+              </Cos72SessionProvider>
             </DashboardProvider>
           </ThemeProvider>
         </I18nProvider>

--- a/aastar-frontend/app/tasks/[taskId]/page.tsx
+++ b/aastar-frontend/app/tasks/[taskId]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Layout from "@/components/Layout";
 import { useTask } from "@/contexts/TaskContext";
-import { useDashboard } from "@/contexts/DashboardContext";
+import { useCos72Session } from "@/contexts/Cos72SessionContext";
 import { getStoredAuth } from "@/lib/auth";
 import { type ParsedTask, TaskStatus, TASK_STATUS_COLORS } from "@/lib/task-types";
 import {
@@ -23,7 +23,6 @@ import {
 } from "@heroicons/react/24/outline";
 import { formatDate, formatDateTime } from "@/lib/date-utils";
 import toast from "react-hot-toast";
-import type { WalletClient } from "viem";
 
 function AddressRow({ label, addr }: { label: string; addr: string }) {
   if (!addr || addr === "0x0000000000000000000000000000000000000000") return null;
@@ -61,12 +60,13 @@ export default function TaskDetailPage() {
     getTaskReceipts,
     linkReceipt,
   } = useTask();
-  const { data } = useDashboard();
+  // Cos72 is AirAccount-only: the smart account is the on-chain actor, so the
+  // contract stores it as community/taskor. Role checks compare against it, and
+  // every write is a gasless sponsored UserOp via `send`.
+  const { send, address: sessionAddress, isConnected } = useCos72Session();
 
   const [task, setTask] = useState<ParsedTask | null>(null);
   const [loading, setLoading] = useState(true);
-  const [walletClient, setWalletClient] = useState<WalletClient | null>(null);
-  const [eoaAddress, setEoaAddress] = useState<string>("");
   const [actionLoading, setActionLoading] = useState(false);
   const [evidenceUri, setEvidenceUri] = useState("");
   const [showEvidenceForm, setShowEvidenceForm] = useState(false);
@@ -79,8 +79,7 @@ export default function TaskDetailPage() {
   const [receiptInput, setReceiptInput] = useState("");
   const [receiptUriInput, setReceiptUriInput] = useState("");
 
-  // Use MetaMask EOA for role checks — contract stores EOA, not YAA smart account
-  const myAddress = (eoaAddress || (data.account?.address ?? "")).toLowerCase();
+  const myAddress = (sessionAddress ?? "").toLowerCase();
   const isCommunity = task?.community.toLowerCase() === myAddress;
   const isTaskor = task?.taskor.toLowerCase() === myAddress;
   const isZeroAddress = (addr: string) => addr === "0x0000000000000000000000000000000000000000";
@@ -89,29 +88,6 @@ export default function TaskDetailPage() {
     const { token } = getStoredAuth();
     if (!token) router.push("/auth/login");
   }, [router]);
-
-  useEffect(() => {
-    async function loadWallet() {
-      if (typeof window === "undefined") return;
-      const { createWalletClient, custom } = await import("viem");
-      const { SUPPORTED_CHAIN } = await import("@/lib/contracts/task-config");
-      const provider = (window as Window & { ethereum?: unknown }).ethereum;
-      if (!provider) return;
-      const client = createWalletClient({
-        chain: SUPPORTED_CHAIN,
-        transport: custom(provider as Parameters<typeof custom>[0]),
-      });
-      setWalletClient(client);
-      // Fetch EOA address for role comparison (contract stores EOA, not YAA smart account)
-      try {
-        const addrs = await client.getAddresses();
-        if (addrs[0]) setEoaAddress(addrs[0].toLowerCase());
-      } catch {
-        // not connected yet — will be resolved on first requestAddresses()
-      }
-    }
-    loadWallet();
-  }, []);
 
   useEffect(() => {
     if (!taskId) return;
@@ -143,19 +119,9 @@ export default function TaskDetailPage() {
     });
   }, [taskId, getTaskReceipts]);
 
-  const switchWallet = async () => {
-    if (!walletClient) return;
-    try {
-      const addrs = await walletClient.requestAddresses();
-      if (addrs[0]) setEoaAddress(addrs[0].toLowerCase());
-    } catch {
-      toast.error("Failed to switch wallet");
-    }
-  };
-
   async function runAction(fn: () => Promise<boolean>, successMsg: string) {
-    if (!walletClient) {
-      toast.error("No wallet connected");
+    if (!isConnected) {
+      toast.error("Passkey login required.");
       return;
     }
     setActionLoading(true);
@@ -253,24 +219,18 @@ export default function TaskDetailPage() {
           </div>
         </div>
 
-        {/* Wallet indicator */}
+        {/* Account indicator */}
         <div className="flex items-center justify-between px-1 text-xs text-gray-500 dark:text-gray-400">
           <span>
-            Wallet:{" "}
-            {eoaAddress ? (
+            AirAccount:{" "}
+            {sessionAddress ? (
               <span className="font-mono">
-                {eoaAddress.slice(0, 6)}…{eoaAddress.slice(-4)}
+                {sessionAddress.slice(0, 6)}…{sessionAddress.slice(-4)}
               </span>
             ) : (
-              <span className="italic">not connected</span>
+              <span className="italic">not signed in</span>
             )}
           </span>
-          <button
-            onClick={switchWallet}
-            className="text-emerald-600 dark:text-emerald-400 hover:underline"
-          >
-            {eoaAddress ? "Switch wallet" : "Connect wallet"}
-          </button>
         </div>
 
         {/* Description */}
@@ -339,7 +299,7 @@ export default function TaskDetailPage() {
         )}
 
         {/* T06: x402 Receipts */}
-        {(receipts.length > 0 || (eoaAddress && (isCommunity || isTaskor))) && (
+        {(receipts.length > 0 || ((isCommunity || isTaskor))) && (
           <Section title="x402 Receipts">
             {receipts.length > 0 ? (
               <div className="space-y-3">
@@ -385,7 +345,7 @@ export default function TaskDetailPage() {
               <p className="text-sm text-gray-500 dark:text-gray-400">No receipts linked yet.</p>
             )}
 
-            {eoaAddress && (isCommunity || isTaskor) && (
+            {(isCommunity || isTaskor) && (
               <div className="mt-3">
                 {!showLinkReceiptForm ? (
                   <button
@@ -423,13 +383,13 @@ export default function TaskDetailPage() {
                       </button>
                       <button
                         onClick={async () => {
-                          if (!receiptInput.trim() || !receiptUriInput.trim() || !walletClient)
+                          if (!receiptInput.trim() || !receiptUriInput.trim() || !isConnected)
                             return;
                           const ok = await linkReceipt(
                             task!.taskId,
                             receiptInput.trim(),
                             receiptUriInput.trim(),
-                            walletClient
+                            send
                           );
                           if (ok) {
                             toast.success("Receipt linked!");
@@ -460,7 +420,7 @@ export default function TaskDetailPage() {
           {isOpen && !isCommunity && !task.isExpired && (
             <button
               onClick={() =>
-                runAction(() => acceptTask(task.taskId, walletClient!), "Task claimed!")
+                runAction(() => acceptTask(task.taskId, send), "Task claimed!")
               }
               disabled={actionLoading}
               className="w-full py-3 rounded-xl bg-emerald-600 hover:bg-emerald-700 disabled:opacity-60 text-white font-semibold text-sm transition-colors"
@@ -502,7 +462,7 @@ export default function TaskDetailPage() {
                       onClick={() => {
                         if (!evidenceUri.trim()) return;
                         runAction(
-                          () => submitWork(task.taskId, evidenceUri.trim(), walletClient!),
+                          () => submitWork(task.taskId, evidenceUri.trim(), send),
                           "Work submitted!"
                         );
                         setShowEvidenceForm(false);
@@ -524,7 +484,7 @@ export default function TaskDetailPage() {
               <button
                 onClick={() =>
                   runAction(
-                    () => approveWork(task.taskId, walletClient!),
+                    () => approveWork(task.taskId, send),
                     "Work approved! Reward distributed."
                   )
                 }
@@ -544,7 +504,7 @@ export default function TaskDetailPage() {
           {task.canFinalize && (
             <button
               onClick={() =>
-                runAction(() => finalizeTask(task.taskId, walletClient!), "Task finalized!")
+                runAction(() => finalizeTask(task.taskId, send), "Task finalized!")
               }
               disabled={actionLoading}
               className="w-full py-3 rounded-xl bg-gray-700 hover:bg-gray-600 disabled:opacity-60 text-white font-semibold text-sm transition-colors"
@@ -558,7 +518,7 @@ export default function TaskDetailPage() {
             <button
               onClick={() =>
                 runAction(
-                  () => cancelTask(task.taskId, walletClient!),
+                  () => cancelTask(task.taskId, send),
                   "Task cancelled. Reward refunded."
                 )
               }

--- a/aastar-frontend/app/tasks/create/page.tsx
+++ b/aastar-frontend/app/tasks/create/page.tsx
@@ -2,20 +2,17 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { parseUnits } from "viem";
 import Layout from "@/components/Layout";
 import { useTask } from "@/contexts/TaskContext";
-import { useDashboard } from "@/contexts/DashboardContext";
+import { useCos72Session } from "@/contexts/Cos72SessionContext";
 import { getStoredAuth } from "@/lib/auth";
 import {
   ALL_TASK_TYPES,
   DEFAULT_REWARD_TOKEN_SYMBOL,
+  DEFAULT_REWARD_TOKEN_DECIMALS,
   TASK_TYPE_GENERAL,
-  X402_API_URL,
-  isX402Configured,
-  REWARD_TOKEN_NAME,
-  REWARD_TOKEN_VERSION,
 } from "@/lib/contracts/task-config";
-import { postTaskWithX402, type X402Receipt } from "@/lib/x402-client";
 import { type CreateTaskForm } from "@/lib/task-types";
 import { ArrowLeftIcon, InformationCircleIcon } from "@heroicons/react/24/outline";
 import toast from "react-hot-toast";
@@ -29,8 +26,11 @@ const DEADLINE_OPTIONS = [
 
 export default function CreateTaskPage() {
   const router = useRouter();
-  const { createTask, approveToken, checkAllowance, contractConfigured, linkReceipt } = useTask();
-  useDashboard();
+  const { createTask, approveToken, checkAllowance, contractConfigured } = useTask();
+  // Cos72 is AirAccount-only: every write is a gasless sponsored UserOp via the
+  // session's `send`. No window.ethereum, no EOA, no EIP-2612 permit (an AA
+  // cannot EOA-sign typed data). Reward escrow = approve(send) + createTask(send).
+  const { send, isConnected, address } = useCos72Session();
 
   const [form, setForm] = useState<CreateTaskForm>({
     title: "",
@@ -39,9 +39,8 @@ export default function CreateTaskPage() {
     deadlineDays: 7,
     taskType: TASK_TYPE_GENERAL,
   });
-  const [step, setStep] = useState<"form" | "x402" | "approve" | "submit" | "linking">("form");
+  const [step, setStep] = useState<"form" | "approve" | "submit">("form");
   const [submitting, setSubmitting] = useState(false);
-  const [walletClient, setWalletClient] = useState<import("viem").WalletClient | null>(null);
 
   useEffect(() => {
     const { token } = getStoredAuth();
@@ -49,23 +48,6 @@ export default function CreateTaskPage() {
       router.push("/auth/login");
     }
   }, [router]);
-
-  // Get wallet client from browser provider (MetaMask / injected)
-  useEffect(() => {
-    async function loadWallet() {
-      if (typeof window === "undefined") return;
-      const { createWalletClient, custom } = await import("viem");
-      const { SUPPORTED_CHAIN } = await import("@/lib/contracts/task-config");
-      const provider = (window as Window & { ethereum?: unknown }).ethereum;
-      if (!provider) return;
-      const client = createWalletClient({
-        chain: SUPPORTED_CHAIN,
-        transport: custom(provider as Parameters<typeof custom>[0]),
-      });
-      setWalletClient(client);
-    }
-    loadWallet();
-  }, []);
 
   const handleUpdate = <K extends keyof CreateTaskForm>(key: K, value: CreateTaskForm[K]) => {
     setForm(prev => ({ ...prev, [key]: value }));
@@ -77,199 +59,41 @@ export default function CreateTaskPage() {
     parseFloat(form.rewardAmount) > 0;
 
   async function handleSubmit() {
-    if (!isValid || !walletClient) return;
+    if (!isValid) return;
+    if (!isConnected || !address) {
+      toast.error("Passkey login required to post a task.");
+      return;
+    }
     if (!contractConfigured) {
       toast.error("Contract not configured. Check NEXT_PUBLIC_TASK_ESCROW_ADDRESS.");
       return;
     }
 
     setSubmitting(true);
-    let x402Receipt: X402Receipt | null = null;
-
     try {
-      const { parseUnits, createPublicClient, http } = await import("viem");
-      const {
-        DEFAULT_REWARD_TOKEN_DECIMALS,
-        DEFAULT_REWARD_TOKEN,
-        TASK_ESCROW_ADDRESS,
-        SUPPORTED_CHAIN,
-        RPC_URL,
-      } = await import("@/lib/contracts/task-config");
-      const { ERC20_ABI, TASK_ESCROW_ABI } = await import("@/lib/contracts/task-escrow-abi");
-
       const rewardWei = parseUnits(form.rewardAmount, DEFAULT_REWARD_TOKEN_DECIMALS);
-      const addresses = await walletClient.requestAddresses();
-      const ownerAddress = addresses[0];
-      const chainId = await walletClient.getChainId();
 
-      const metadata = JSON.stringify({
-        title: form.title,
-        description: form.description,
-        createdAt: Math.floor(Date.now() / 1000),
-      });
-      const deadlineBig = BigInt(Math.floor(Date.now() / 1000) + form.deadlineDays * 86400);
-
-      const publicClient = createPublicClient({ chain: SUPPORTED_CHAIN, transport: http(RPC_URL) });
-
-      // ── Step 1: x402 payment (if API server is configured) ──────────────
-      if (isX402Configured()) {
-        setStep("x402");
-        toast.loading("Signing x402 payment...", { id: "x402" });
-        try {
-          x402Receipt = await postTaskWithX402(
-            X402_API_URL,
-            {
-              title: form.title,
-              description: form.description,
-              rewardAmount: form.rewardAmount,
-              deadlineDays: form.deadlineDays,
-              taskType: form.taskType,
-            },
-            walletClient,
-            DEFAULT_REWARD_TOKEN,
-            REWARD_TOKEN_NAME,
-            REWARD_TOKEN_VERSION,
-            chainId
-          );
-          toast.dismiss("x402");
-          toast.success("x402 payment signed");
-        } catch (x402Err) {
-          toast.dismiss("x402");
-          // Non-fatal: warn and continue with on-chain creation
-          console.warn("[x402] Payment failed, continuing without receipt:", x402Err);
-          toast.error(
-            `x402 skipped: ${x402Err instanceof Error ? x402Err.message : "unknown error"}`,
-            { duration: 4000 }
-          );
+      // ── Step 1: ensure the escrow can pull the reward (skip once xPNTs auto-
+      // approves the escrow spender; mock USDC needs an explicit approve). ──
+      const currentAllowance = await checkAllowance(address);
+      if (currentAllowance < rewardWei) {
+        setStep("approve");
+        toast.loading("Approving reward token (gasless)...", { id: "approve" });
+        const approved = await approveToken(rewardWei, send);
+        toast.dismiss("approve");
+        if (!approved) {
+          toast.error("Token approval failed");
+          setStep("form");
+          return;
         }
+        toast.success("Token approved");
       }
 
-      // ── Step 2: on-chain task creation (permit or approve+create) ────────
-      let taskId: `0x${string}` | null = null;
-      let usedPermit = false;
-
-      try {
-        const [tokenName, nonce] = await Promise.all([
-          publicClient.readContract({
-            address: DEFAULT_REWARD_TOKEN,
-            abi: ERC20_ABI,
-            functionName: "name",
-          }),
-          publicClient.readContract({
-            address: DEFAULT_REWARD_TOKEN,
-            abi: ERC20_ABI,
-            functionName: "nonces",
-            args: [ownerAddress],
-          }),
-        ]);
-
-        const permitDeadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
-
-        const permitSig = await walletClient.signTypedData({
-          account: ownerAddress,
-          domain: {
-            name: tokenName as string,
-            version: REWARD_TOKEN_VERSION,
-            chainId,
-            verifyingContract: DEFAULT_REWARD_TOKEN,
-          },
-          types: {
-            Permit: [
-              { name: "owner", type: "address" },
-              { name: "spender", type: "address" },
-              { name: "value", type: "uint256" },
-              { name: "nonce", type: "uint256" },
-              { name: "deadline", type: "uint256" },
-            ],
-          },
-          primaryType: "Permit",
-          message: {
-            owner: ownerAddress,
-            spender: TASK_ESCROW_ADDRESS,
-            value: rewardWei,
-            nonce: nonce as bigint,
-            deadline: permitDeadline,
-          },
-        });
-
-        const r = `0x${permitSig.slice(2, 66)}` as `0x${string}`;
-        const s = `0x${permitSig.slice(66, 130)}` as `0x${string}`;
-        const v = parseInt(permitSig.slice(130, 132), 16);
-
-        setStep("submit");
-        toast.loading("Creating task on-chain (single tx)...", { id: "create" });
-
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "createTaskWithPermit",
-          args: [
-            DEFAULT_REWARD_TOKEN,
-            rewardWei,
-            deadlineBig,
-            metadata,
-            form.taskType,
-            permitDeadline,
-            v,
-            r,
-            s,
-          ],
-          account: ownerAddress,
-          chain: SUPPORTED_CHAIN,
-        });
-
-        const receipt = await publicClient.waitForTransactionReceipt({ hash });
-        const log = receipt.logs.find(
-          l => l.address.toLowerCase() === TASK_ESCROW_ADDRESS.toLowerCase()
-        );
-        if (log?.topics[1]) {
-          taskId = log.topics[1] as `0x${string}`;
-          usedPermit = true;
-        }
-      } catch {
-        // Permit not supported — fall back to approve + createTask
-      }
-
-      if (!usedPermit) {
-        const currentAllowance = await checkAllowance(ownerAddress);
-        if (currentAllowance < rewardWei) {
-          setStep("approve");
-          toast.loading("Approving token spend...", { id: "approve" });
-          const approved = await approveToken(rewardWei, walletClient);
-          toast.dismiss("approve");
-          if (!approved) {
-            toast.error("Token approval failed");
-            setStep("form");
-            return;
-          }
-          toast.success("Token approved");
-        }
-
-        setStep("submit");
-        toast.loading("Creating task on-chain...", { id: "create" });
-        taskId = await createTask(form, walletClient);
-      }
-
+      // ── Step 2: create the task on-chain (gasless sponsored UserOp). ──
+      setStep("submit");
+      toast.loading("Creating task on-chain (gasless)...", { id: "create" });
+      const taskId = await createTask(form, send);
       toast.dismiss("create");
-
-      // ── Step 3: auto-link x402 receipt (if we have both) ─────────────────
-      if (taskId && x402Receipt) {
-        setStep("linking");
-        toast.loading("Linking x402 receipt on-chain...", { id: "link" });
-        const linked = await linkReceipt(
-          taskId,
-          x402Receipt.receiptId,
-          x402Receipt.receiptUri,
-          walletClient
-        );
-        toast.dismiss("link");
-        if (!linked) {
-          // Non-fatal: task was created, receipt just wasn't linked
-          toast.error("Receipt linking failed — you can link it manually on the task page", {
-            duration: 5000,
-          });
-        }
-      }
 
       if (taskId) {
         toast.success("Task created successfully!");
@@ -285,9 +109,6 @@ export default function CreateTaskPage() {
       setSubmitting(false);
     }
   }
-
-  const hasEthereum =
-    typeof window !== "undefined" && !!(window as Window & { ethereum?: unknown }).ethereum;
 
   return (
     <Layout requireAuth>
@@ -308,12 +129,13 @@ export default function CreateTaskPage() {
           </div>
         </div>
 
-        {/* No wallet warning */}
-        {!hasEthereum && (
+        {/* Not-logged-in warning */}
+        {!isConnected && (
           <div className="mb-5 p-4 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 text-sm text-yellow-800 dark:text-yellow-400 flex gap-2">
             <InformationCircleIcon className="w-5 h-5 shrink-0 mt-0.5" />
             <p>
-              No wallet detected. Install MetaMask or another Web3 wallet to create tasks on-chain.
+              Sign in with your passkey to post a task. Rewards are escrowed gaslessly from your
+              AirAccount — no wallet extension, no ETH for gas.
             </p>
           </div>
         )}
@@ -442,22 +264,16 @@ export default function CreateTaskPage() {
           {/* Submit */}
           <button
             onClick={handleSubmit}
-            disabled={!isValid || submitting || !walletClient}
+            disabled={!isValid || submitting || !isConnected}
             className="w-full py-3 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:bg-gray-300 dark:disabled:bg-gray-700 text-white disabled:text-gray-500 font-medium text-sm transition-colors"
           >
             {submitting
-              ? step === "x402"
-                ? "Signing x402 payment..."
-                : step === "approve"
-                  ? "Approving token..."
-                  : step === "linking"
-                    ? "Linking receipt..."
-                    : "Creating task..."
-              : !walletClient
-                ? "Connect wallet to post"
-                : isX402Configured()
-                  ? "Post Task (x402 + Permit)"
-                  : "Post Task (EIP-2612 Permit)"}
+              ? step === "approve"
+                ? "Approving token..."
+                : "Creating task..."
+              : !isConnected
+                ? "Sign in to post"
+                : "Post Task (gasless)"}
           </button>
         </div>
       </div>

--- a/aastar-frontend/contexts/TaskContext.tsx
+++ b/aastar-frontend/contexts/TaskContext.tsx
@@ -1,24 +1,17 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
-import {
-  parseUnits,
-  formatUnits,
-  keccak256,
-  toBytes,
-  type PublicClient,
-  type WalletClient,
-} from "viem";
+import { parseUnits, formatUnits, keccak256, toBytes, type PublicClient } from "viem";
 import { TASK_ESCROW_ABI, ERC20_ABI } from "@/lib/contracts/task-escrow-abi";
 import {
   TASK_ESCROW_ADDRESS,
   DEFAULT_REWARD_TOKEN,
   DEFAULT_REWARD_TOKEN_DECIMALS,
   TASK_TYPE_LABELS,
-  SUPPORTED_CHAIN,
   isContractsConfigured,
   getPublicClient,
 } from "@/lib/contracts/task-config";
+import type { ContractCall } from "@/lib/sdk/cosTx";
 import {
   type Task,
   type ParsedTask,
@@ -26,6 +19,14 @@ import {
   TaskStatus,
   TASK_STATUS_LABELS,
 } from "@/lib/task-types";
+
+/**
+ * Every write goes through the Cos72 session's gasless `send` (cosSend). It
+ * resolves once the sponsored UserOp is mined (cosSend polls for the tx hash),
+ * so callers get the on-chain tx hash back and no longer manage a walletClient
+ * or an EOA. Pass `useCos72Session().send` into any write below.
+ */
+type SendFn = (call: ContractCall) => Promise<`0x${string}`>;
 
 interface TaskContextType {
   // Data
@@ -42,23 +43,23 @@ interface TaskContextType {
   // Actions
   loadAllTasks: () => Promise<void>;
   loadMyTasks: (address: string) => Promise<void>;
-  createTask: (form: CreateTaskForm, walletClient: WalletClient) => Promise<`0x${string}` | null>;
-  acceptTask: (taskId: string, walletClient: WalletClient) => Promise<boolean>;
-  submitWork: (taskId: string, evidenceUri: string, walletClient: WalletClient) => Promise<boolean>;
-  approveWork: (taskId: string, walletClient: WalletClient) => Promise<boolean>;
-  finalizeTask: (taskId: string, walletClient: WalletClient) => Promise<boolean>;
-  cancelTask: (taskId: string, walletClient: WalletClient) => Promise<boolean>;
+  createTask: (form: CreateTaskForm, send: SendFn) => Promise<`0x${string}` | null>;
+  acceptTask: (taskId: string, send: SendFn) => Promise<boolean>;
+  submitWork: (taskId: string, evidenceUri: string, send: SendFn) => Promise<boolean>;
+  approveWork: (taskId: string, send: SendFn) => Promise<boolean>;
+  finalizeTask: (taskId: string, send: SendFn) => Promise<boolean>;
+  cancelTask: (taskId: string, send: SendFn) => Promise<boolean>;
   // T06: Receipts
   getTaskReceipts: (taskId: string) => Promise<`0x${string}`[]>;
   linkReceipt: (
     taskId: string,
     receiptId: string,
     receiptUri: string,
-    walletClient: WalletClient
+    send: SendFn
   ) => Promise<boolean>;
   // Helpers
   getTask: (taskId: string) => Promise<ParsedTask | null>;
-  approveToken: (amount: bigint, walletClient: WalletClient) => Promise<boolean>;
+  approveToken: (amount: bigint, send: SendFn) => Promise<boolean>;
   checkAllowance: (ownerAddress: string) => Promise<bigint>;
 }
 
@@ -224,31 +225,22 @@ export function TaskProvider({ children }: { children: ReactNode }) {
     return allowance as bigint;
   }, []);
 
-  const approveToken = useCallback(
-    async (amount: bigint, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
-      try {
-        const hash = await walletClient.writeContract({
-          address: DEFAULT_REWARD_TOKEN,
-          abi: ERC20_ABI,
-          functionName: "approve",
-          args: [TASK_ESCROW_ADDRESS, amount],
-          account: address,
-          chain: SUPPORTED_CHAIN,
-        });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const approveToken = useCallback(async (amount: bigint, send: SendFn): Promise<boolean> => {
+    try {
+      await send({
+        to: DEFAULT_REWARD_TOKEN,
+        abi: ERC20_ABI,
+        functionName: "approve",
+        args: [TASK_ESCROW_ADDRESS, amount],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
   const createTask = useCallback(
-    async (form: CreateTaskForm, walletClient: WalletClient): Promise<`0x${string}` | null> => {
-      const [address] = await walletClient.requestAddresses();
+    async (form: CreateTaskForm, send: SendFn): Promise<`0x${string}` | null> => {
       const reward = parseUnits(form.rewardAmount, DEFAULT_REWARD_TOKEN_DECIMALS);
       const deadline = BigInt(Math.floor(Date.now() / 1000) + form.deadlineDays * 86400);
 
@@ -260,26 +252,20 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       });
 
       try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
+        const hash = await send({
+          to: TASK_ESCROW_ADDRESS,
           abi: TASK_ESCROW_ABI,
           functionName: "createTask",
           args: [DEFAULT_REWARD_TOKEN, reward, deadline, metadata, form.taskType],
-          account: address,
-          chain: SUPPORTED_CHAIN,
         });
 
+        // send() resolves once mined; read the receipt to extract the taskId.
         const client = getPublicClient();
         const receipt = await client.waitForTransactionReceipt({ hash });
-
-        // Extract taskId from TaskCreated event
         const log = receipt.logs.find(
           l => l.address.toLowerCase() === TASK_ESCROW_ADDRESS.toLowerCase()
         );
-        if (log?.topics[1]) {
-          return log.topics[1] as `0x${string}`;
-        }
-        return null;
+        return (log?.topics[1] as `0x${string}` | undefined) ?? null;
       } catch {
         return null;
       }
@@ -287,42 +273,29 @@ export function TaskProvider({ children }: { children: ReactNode }) {
     []
   );
 
-  const acceptTask = useCallback(
-    async (taskId: string, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
-      try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "acceptTask",
-          args: [taskId as `0x${string}`],
-          account: address,
-          chain: SUPPORTED_CHAIN,
-        });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const acceptTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
+    try {
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "acceptTask",
+        args: [taskId as `0x${string}`],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
   const submitWork = useCallback(
-    async (taskId: string, evidenceUri: string, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
+    async (taskId: string, evidenceUri: string, send: SendFn): Promise<boolean> => {
       try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
+        await send({
+          to: TASK_ESCROW_ADDRESS,
           abi: TASK_ESCROW_ABI,
           functionName: "submitWork",
           args: [taskId as `0x${string}`, evidenceUri],
-          account: address,
-          chain: SUPPORTED_CHAIN,
         });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
         return true;
       } catch {
         return false;
@@ -331,71 +304,47 @@ export function TaskProvider({ children }: { children: ReactNode }) {
     []
   );
 
-  const approveWork = useCallback(
-    async (taskId: string, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
-      try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "approveWork",
-          args: [taskId as `0x${string}`],
-          account: address,
-          chain: SUPPORTED_CHAIN,
-        });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const approveWork = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
+    try {
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "approveWork",
+        args: [taskId as `0x${string}`],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
-  const finalizeTask = useCallback(
-    async (taskId: string, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
-      try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "finalizeTask",
-          args: [taskId as `0x${string}`],
-          account: address,
-          chain: SUPPORTED_CHAIN,
-        });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const finalizeTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
+    try {
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "finalizeTask",
+        args: [taskId as `0x${string}`],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
-  const cancelTask = useCallback(
-    async (taskId: string, walletClient: WalletClient): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
-      try {
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "cancelTask",
-          args: [taskId as `0x${string}`],
-          account: address,
-          chain: SUPPORTED_CHAIN,
-        });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    []
-  );
+  const cancelTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
+    try {
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "cancelTask",
+        args: [taskId as `0x${string}`],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
 
   // T01: load task token balance for a given address
   const loadTaskTokenBalance = useCallback(async (address: string) => {
@@ -442,25 +391,20 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       taskId: string,
       receiptId: string,
       receiptUri: string,
-      walletClient: WalletClient
+      send: SendFn
     ): Promise<boolean> => {
-      const [address] = await walletClient.requestAddresses();
       try {
         // receiptId must be bytes32; if it's a plain string, hash it
         const receiptIdBytes =
           receiptId.startsWith("0x") && receiptId.length === 66
             ? (receiptId as `0x${string}`)
             : keccak256(toBytes(receiptId));
-        const hash = await walletClient.writeContract({
-          address: TASK_ESCROW_ADDRESS,
+        await send({
+          to: TASK_ESCROW_ADDRESS,
           abi: TASK_ESCROW_ABI,
           functionName: "linkReceipt",
           args: [taskId as `0x${string}`, receiptIdBytes, receiptUri],
-          account: address,
-          chain: SUPPORTED_CHAIN,
         });
-        const client = getPublicClient();
-        await client.waitForTransactionReceipt({ hash });
         return true;
       } catch {
         return false;

--- a/aastar-frontend/contexts/TaskContext.tsx
+++ b/aastar-frontend/contexts/TaskContext.tsx
@@ -20,6 +20,10 @@ import {
   TASK_STATUS_LABELS,
 } from "@/lib/task-types";
 
+/** keccak256("TaskCreated(bytes32,address,address,uint256)") — used to verify the
+ *  emitting event (topic0), not just the emitting address, when reading a receipt. */
+const TASK_CREATED_TOPIC = keccak256(toBytes("TaskCreated(bytes32,address,address,uint256)"));
+
 /**
  * Every write goes through the Cos72 session's gasless `send` (cosSend). It
  * resolves once the sponsored UserOp is mined (cosSend polls for the tx hash),
@@ -226,17 +230,13 @@ export function TaskProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const approveToken = useCallback(async (amount: bigint, send: SendFn): Promise<boolean> => {
-    try {
-      await send({
-        to: DEFAULT_REWARD_TOKEN,
-        abi: ERC20_ABI,
-        functionName: "approve",
-        args: [TASK_ESCROW_ADDRESS, amount],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    await send({
+      to: DEFAULT_REWARD_TOKEN,
+      abi: ERC20_ABI,
+      functionName: "approve",
+      args: [TASK_ESCROW_ADDRESS, amount],
+    });
+    return true;
   }, []);
 
   const createTask = useCallback(
@@ -251,99 +251,80 @@ export function TaskProvider({ children }: { children: ReactNode }) {
         createdAt: Math.floor(Date.now() / 1000),
       });
 
-      try {
-        const hash = await send({
-          to: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "createTask",
-          args: [DEFAULT_REWARD_TOKEN, reward, deadline, metadata, form.taskType],
-        });
+      // Let send() surface its own errors (revert reason / timeout) to the caller.
+      const hash = await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "createTask",
+        args: [DEFAULT_REWARD_TOKEN, reward, deadline, metadata, form.taskType],
+      });
 
-        // send() resolves once mined; read the receipt to extract the taskId.
-        const client = getPublicClient();
-        const receipt = await client.waitForTransactionReceipt({ hash });
-        const log = receipt.logs.find(
-          l => l.address.toLowerCase() === TASK_ESCROW_ADDRESS.toLowerCase()
-        );
-        return (log?.topics[1] as `0x${string}` | undefined) ?? null;
-      } catch {
-        return null;
-      }
+      // send() resolves once mined; read the receipt to extract the taskId. Match
+      // the emitting event by BOTH the escrow address AND the TaskCreated topic0 so
+      // an unrelated same-address log can't be misread as the taskId.
+      const client = getPublicClient();
+      const receipt = await client.waitForTransactionReceipt({ hash });
+      const log = receipt.logs.find(
+        l =>
+          l.address.toLowerCase() === TASK_ESCROW_ADDRESS.toLowerCase() &&
+          l.topics[0] === TASK_CREATED_TOPIC
+      );
+      return (log?.topics[1] as `0x${string}` | undefined) ?? null;
     },
     []
   );
 
   const acceptTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
-    try {
-      await send({
-        to: TASK_ESCROW_ADDRESS,
-        abi: TASK_ESCROW_ABI,
-        functionName: "acceptTask",
-        args: [taskId as `0x${string}`],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    await send({
+      to: TASK_ESCROW_ADDRESS,
+      abi: TASK_ESCROW_ABI,
+      functionName: "acceptTask",
+      args: [taskId as `0x${string}`],
+    });
+    return true;
   }, []);
 
   const submitWork = useCallback(
     async (taskId: string, evidenceUri: string, send: SendFn): Promise<boolean> => {
-      try {
-        await send({
-          to: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "submitWork",
-          args: [taskId as `0x${string}`, evidenceUri],
-        });
-        return true;
-      } catch {
-        return false;
-      }
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "submitWork",
+        args: [taskId as `0x${string}`, evidenceUri],
+      });
+      return true;
     },
     []
   );
 
   const approveWork = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
-    try {
-      await send({
-        to: TASK_ESCROW_ADDRESS,
-        abi: TASK_ESCROW_ABI,
-        functionName: "approveWork",
-        args: [taskId as `0x${string}`],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    await send({
+      to: TASK_ESCROW_ADDRESS,
+      abi: TASK_ESCROW_ABI,
+      functionName: "approveWork",
+      args: [taskId as `0x${string}`],
+    });
+    return true;
   }, []);
 
   const finalizeTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
-    try {
-      await send({
-        to: TASK_ESCROW_ADDRESS,
-        abi: TASK_ESCROW_ABI,
-        functionName: "finalizeTask",
-        args: [taskId as `0x${string}`],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    await send({
+      to: TASK_ESCROW_ADDRESS,
+      abi: TASK_ESCROW_ABI,
+      functionName: "finalizeTask",
+      args: [taskId as `0x${string}`],
+    });
+    return true;
   }, []);
 
   const cancelTask = useCallback(async (taskId: string, send: SendFn): Promise<boolean> => {
-    try {
-      await send({
-        to: TASK_ESCROW_ADDRESS,
-        abi: TASK_ESCROW_ABI,
-        functionName: "cancelTask",
-        args: [taskId as `0x${string}`],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    await send({
+      to: TASK_ESCROW_ADDRESS,
+      abi: TASK_ESCROW_ABI,
+      functionName: "cancelTask",
+      args: [taskId as `0x${string}`],
+    });
+    return true;
   }, []);
 
   // T01: load task token balance for a given address
@@ -393,22 +374,18 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       receiptUri: string,
       send: SendFn
     ): Promise<boolean> => {
-      try {
-        // receiptId must be bytes32; if it's a plain string, hash it
-        const receiptIdBytes =
-          receiptId.startsWith("0x") && receiptId.length === 66
-            ? (receiptId as `0x${string}`)
-            : keccak256(toBytes(receiptId));
-        await send({
-          to: TASK_ESCROW_ADDRESS,
-          abi: TASK_ESCROW_ABI,
-          functionName: "linkReceipt",
-          args: [taskId as `0x${string}`, receiptIdBytes, receiptUri],
-        });
-        return true;
-      } catch {
-        return false;
-      }
+      // receiptId must be bytes32; if it's a plain string, hash it
+      const receiptIdBytes =
+        receiptId.startsWith("0x") && receiptId.length === 66
+          ? (receiptId as `0x${string}`)
+          : keccak256(toBytes(receiptId));
+      await send({
+        to: TASK_ESCROW_ADDRESS,
+        abi: TASK_ESCROW_ABI,
+        functionName: "linkReceipt",
+        args: [taskId as `0x${string}`, receiptIdBytes, receiptUri],
+      });
+      return true;
     },
     []
   );


### PR DESCRIPTION
## Phase 1 — MyTask 写路径全部走 cosSend gasless

把 YAA 成熟的 `app/tasks` 三页从 `window.ethereum`/EOA 写路径，切到 Cos72 的 AirAccount-only gasless `send`（Phase 0 §0.2 的 cosSend）。

### 改动
- **`contexts/TaskContext.tsx`** — 8 个写函数签名 `walletClient: WalletClient` → `send: (call: ContractCall) => Promise<Hash>`（= `useCos72Session().send`）。每个 `walletClient.writeContract({...})` → `send({to,abi,functionName,args})`，去掉 `requestAddresses`。`send` resolve 即已上链（cosSend 内部轮询 txHash），故去掉多余的 `waitForTransactionReceipt`；`createTask` 保留 receipt 读取以从 `TaskCreated` log 取 taskId。
- **`app/tasks/create/page.tsx`** — 去掉 `window.ethereum` walletClient、**EIP-2612 permit**（AA 不能 EOA 签 typed-data）、**x402 EOA 签名支付**。改为 `checkAllowance(address) → approveToken(send) → createTask(send)` 两步 gasless（当前 mock USDC 需 approve；换真 xPNTs 且把 escrow 加进 `autoApprovedSpenders` 后变一步）。"no wallet" 警告 → passkey 登录提示。
- **`app/tasks/[taskId]/page.tsx`** — 去掉 EOA/`switchWallet`/`window.ethereum`。角色判断（isCommunity/isTaskor）改用会话 **AirAccount 地址** —— 合约里存的 community/taskor 就是 AA 账户（`createTask` 的 msg.sender 经 UserOp = AA 账户），这同时修正了旧 YAA 拿 MetaMask EOA 比对的错。5 个 action（accept/submit/approve/finalize/cancel）+ 手动 linkReceipt 全传 `send`。

### 验证
- `type-check` ✅ / `build` ✅（`/tasks`、`/tasks/[taskId]`、`/tasks/create` 全编译）
- 本 PR 4 个文件 `eslint` ✅ 干净。仓库其余文件的 react-compiler lint 错继承自 YAA seed（master 上就红），非本 PR 引入。

### 说明 / 后续
- **x402 自动支付**在 create 流程中移除（依赖 EOA typed-data 签名，AA 不兼容）；详情页的 receipt 只读展示 + 手动 link 仍保留并走 gasless。
- 前置依赖 `Cos72SessionProvider` 全局挂载（本分支首个 commit `999d274`）。
- 尚未端到端真跑（需起后端 `/userop` + 配 RPC/KMS + passkey 登录）—— 见 HANDOFF §4 步骤 2。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
