### PR TITLE
fix(test): e2e PaymasterV4 canonical 从 SDK 引,不再硬编码

### DIFF
--- a/aastar/test/app.e2e-spec.ts
+++ b/aastar/test/app.e2e-spec.ts
@@ -3,10 +3,15 @@ import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { Test } from "@nestjs/testing";
 import { AppModule } from "../src/app.module";
+import { getCanonicalAddresses } from "@aastar/sdk/core";
 
-// The canonical Sepolia PaymasterV4 (aPNTs gas token) from @aastar/sdk@0.26.x.
-// Asserting it here guards against the stale 0x1f0D… address regression (PR #357).
-const CANONICAL_PAYMASTER_V4 = "0x957852251f44570dc2B60Dde0954f191FF3372eE";
+// Canonical Sepolia PaymasterV4 (aPNTs gas token) read from the @aastar/sdk canonical
+// table — the SAME source the endpoint uses (paymaster.service → getCanonicalAddresses),
+// so the assertion tracks SDK bumps instead of going stale on a hardcoded address
+// (was 0x9578…, which drifted after the 0.42 bump). Still guards the endpoint's preset
+// plumbing: it must surface the SDK canonical, not a hardcoded/mis-plumbed value.
+const CANONICAL_PAYMASTER_V4 = (getCanonicalAddresses(11155111) as Record<string, string>)
+  .paymasterV4;
 
 describe("App e2e (HTTP layer)", () => {
   let app: INestApplication;


### PR DESCRIPTION
## 修 e2e 陈旧断言 — PaymasterV4 canonical 从 SDK 引

### 问题
`aastar/test/app.e2e-spec.ts` 硬编码 `CANONICAL_PAYMASTER_V4 = 0x9578…72ee`。SDK 0.42 bump(PR #7)把 canonical PaymasterV4 换成 `0xf394…fa0e`,`/paymaster/presets` 端点(`paymaster.service` 走 `getCanonicalAddresses`)返回新地址,硬编码断言漂了 → **e2e 14/15 红**。该断言上次改动是 #358,早于 0.42 bump。

### 修法
断言从 **SDK 同源**取值 —— `getCanonicalAddresses(11155111).paymasterV4`,和端点用的是同一张表,随 SDK bump 走,永不再陈旧。仍保留原意图:端点必须**如实surface SDK canonical**,而非硬编码/接错。

### 验证
- 后端 e2e **15/15** ✅(原 14/15)
- 后端 type-check ✅ / prettier ✅

与 Phase 1(PR #8,纯前端)无关;这是 PR #7 SDK bump 引入的陈旧断言,独立小修。

https://claude.ai/code/session_01RajETCvboSvhadpqMbekNx
