### PR TITLE
fix(deploy): ecosystem 透传 SSO_JWT_SECRET(修 PM2 启动崩溃)+ MyTask index env

### DIFF
--- a/aastar/.env.example
+++ b/aastar/.env.example
@@ -44,3 +44,8 @@ EMAIL_FROM=hi@aastar.io
 # allowed redirect_uri prefixes (fail-closed: empty/unset rejects every SSO authorize).
 SSO_JWT_SECRET=<32-byte-hex-secret-distinct-from-JWT_SECRET>
 SSO_ALLOWED_REDIRECTS=http://localhost:5175,https://myvote.example.com
+
+# MyTask challenge indexer (A-8 consumer, PR #20). Defaults to the MT-8 Sepolia deployment.
+# Empty MYTASK_ESCROW_ADDRESS disables MyTask indexing (skips at boot, does not crash).
+MYTASK_ESCROW_ADDRESS=0x171234DD282eF2909ec20dafC3F81deBa6761178
+MYTASK_INDEX_FROM_BLOCK=11269271

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -43,6 +43,16 @@ module.exports = {
         PIMLICO_API_KEY: process.env.PIMLICO_API_KEY,
         KMS_ENABLED: "true",
         KMS_ENDPOINT: "https://kms.aastar.io",
+        // MyVote SSO (PR #18): SsoService FAILS FAST on boot if SSO_JWT_SECRET is unset — must be
+        // passed through here or the PM2/Docker backend crashes at startup. Must differ from
+        // JWT_SECRET. SSO_ALLOWED_REDIRECTS is a comma-separated exact-URL whitelist (empty =
+        // reject all, fail-closed) — set it to MyVote's `https://<myvote>/sso/callback`.
+        SSO_JWT_SECRET: process.env.SSO_JWT_SECRET,
+        SSO_ALLOWED_REDIRECTS: process.env.SSO_ALLOWED_REDIRECTS || "",
+        // MyTask challenge indexer (PR #20): defaults to the MT-8 Sepolia deployment; override per
+        // environment. Empty MYTASK_ESCROW_ADDRESS disables the indexer (skips, does not crash).
+        MYTASK_ESCROW_ADDRESS: process.env.MYTASK_ESCROW_ADDRESS,
+        MYTASK_INDEX_FROM_BLOCK: process.env.MYTASK_INDEX_FROM_BLOCK,
       },
     },
     {


### PR DESCRIPTION
## 问题

PR#18 的 SsoService 对缺失 `SSO_JWT_SECRET` **fail-fast**(启动即崩),但 `ecosystem.config.js`(PM2 生产部署配置)**未透传该 env** → #18 合并后,Docker/PM2 部署的后端会**启动崩溃**。

## 修复

- ecosystem.config.js 后端 env 块透传 `SSO_JWT_SECRET`(须 ≠ JWT_SECRET)+ `SSO_ALLOWED_REDIRECTS`(空=fail-closed)+ MyTask indexer 的 `MYTASK_ESCROW_ADDRESS`/`MYTASK_INDEX_FROM_BLOCK`(后者有默认,空则跳过不崩)
- `.env.example` 补 MyTask index 两条(SSO 两条 #18 已有)
- `node -e require` 校验 ecosystem 语法通过

纯部署配置一致性,无代码逻辑。

https://claude.ai/code/session_01MCxVCnKkpzi5sCGf1FZ4CH